### PR TITLE
remove warning on deprecated `depends_on`

### DIFF
--- a/otps.rb
+++ b/otps.rb
@@ -6,7 +6,7 @@ class Otps < Formula
 
   option "with-tpxo8", "Install TPXO8-atlas-compact tide model"
 
-  depends_on :fortran
+  depends_on :gcc
 
   resource "tpxo8" do
     url "ftp://anonymous:anonymous%40homebrew.com@ftp.oce.orst.edu/dist/tides/TPXO8_compact/tpxo8_atlas_compact_v1.tar.Z"

--- a/otps.rb
+++ b/otps.rb
@@ -6,7 +6,7 @@ class Otps < Formula
 
   option "with-tpxo8", "Install TPXO8-atlas-compact tide model"
 
-  depends_on :gcc
+  depends_on "gcc"
 
   resource "tpxo8" do
     url "ftp://anonymous:anonymous%40homebrew.com@ftp.oce.orst.edu/dist/tides/TPXO8_compact/tpxo8_atlas_compact_v1.tar.Z"


### PR DESCRIPTION
Warning: Calling 'depends_on :fortran' is deprecated!
Use `depends_on "gcc"` instead.
/Applications/Grass74.app/Contents/Resources/homebrew/Library/Taps/zimonkaizoku/homebrew-mbsystem/otps.rb:9:in `<class:Otps>'
Please report this to the zimonkaizoku/mbsystem tap!